### PR TITLE
fix: enforce RLS for table owner with FORCE ROW LEVEL SECURITY

### DIFF
--- a/django_rls/models.py
+++ b/django_rls/models.py
@@ -1,13 +1,13 @@
 """RLS Model base class."""
 
 import logging
-from typing import List, Optional, Type, TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
-from django.db import models, connection
+from django.db import models
 from django.db.models.signals import post_migrate
 from django.dispatch import receiver
 
-from .exceptions import PolicyError, ConfigurationError
+from .exceptions import ConfigurationError, PolicyError
 
 if TYPE_CHECKING:
     from .policies import BasePolicy
@@ -17,19 +17,19 @@ logger = logging.getLogger(__name__)
 
 class RLSModelMeta(models.base.ModelBase):
     """Metaclass for RLS models."""
-    
+
     def __new__(cls, name, bases, namespace, **kwargs):
         # Extract rls_policies from Meta before Django processes it
-        meta = namespace.get('Meta')
+        meta = namespace.get("Meta")
         rls_policies = []
         if meta:
-            rls_policies = getattr(meta, 'rls_policies', [])
+            rls_policies = getattr(meta, "rls_policies", [])
             # Remove it so Django doesn't complain
-            if hasattr(meta, 'rls_policies'):
-                delattr(meta, 'rls_policies')
-        
+            if hasattr(meta, "rls_policies"):
+                delattr(meta, "rls_policies")
+
         new_class = super().__new__(cls, name, bases, namespace, **kwargs)
-        
+
         # Process RLS policies
         if rls_policies:
             cls._validate_policies(rls_policies)
@@ -37,23 +37,23 @@ class RLSModelMeta(models.base.ModelBase):
         else:
             # Check if any parent class has RLS policies
             for base in bases:
-                if hasattr(base, '_rls_policies'):
+                if hasattr(base, "_rls_policies"):
                     new_class._rls_policies = base._rls_policies
                     break
             else:
                 new_class._rls_policies = []
-            
+
         return new_class
-    
+
     @staticmethod
-    def _validate_policies(policies: List['BasePolicy']) -> None:
+    def _validate_policies(policies: List["BasePolicy"]) -> None:
         """Validate RLS policies."""
         if not isinstance(policies, list):
             raise ConfigurationError("rls_policies must be a list")
-        
+
         # Import here to avoid circular dependency
         from .policies import BasePolicy
-        
+
         for policy in policies:
             if not isinstance(policy, BasePolicy):
                 raise PolicyError(f"Policy {policy} must inherit from BasePolicy")
@@ -61,27 +61,30 @@ class RLSModelMeta(models.base.ModelBase):
 
 class RLSModel(models.Model, metaclass=RLSModelMeta):
     """Base model class that provides RLS functionality."""
-    
+
     class Meta:
         abstract = True
-    
+
     @classmethod
     def enable_rls(cls) -> None:
         """Enable RLS for this model's table."""
         from django.db import connections
-        
+
         # Models don't have _state, use default connection
-        db_alias = 'default'
+        db_alias = "default"
         connection = connections[db_alias]
-        
+
         with connection.schema_editor() as schema_editor:
-            if hasattr(schema_editor, 'enable_rls'):
+            if hasattr(schema_editor, "enable_rls"):
                 # Enable RLS
                 schema_editor.enable_rls(cls)
-                
+
+                # Force RLS to apply even to table owner
+                schema_editor.force_rls(cls)
+
                 # Create policies
                 from django.db import transaction, utils
-                
+
                 for policy in cls._rls_policies:
                     try:
                         # Try to create. Use atomic to allow recovery if it fails.
@@ -90,36 +93,38 @@ class RLSModel(models.Model, metaclass=RLSModelMeta):
                     except utils.ProgrammingError as e:
                         # If policy exists, update it
                         if "already exists" in str(e):
-                            logger.info(f"Policy {policy.name} exists, updating definition.")
+                            logger.info(
+                                f"Policy {policy.name} exists, updating definition."
+                            )
                             schema_editor.alter_policy(cls, policy)
                         else:
                             raise
-                    
+
                 logger.info(f"RLS enabled for {cls._meta.db_table}")
             else:
                 logger.warning(
                     f"Database backend {connection.vendor} does not support RLS. "
                     f"Use 'django_rls.backends.postgresql' as your database ENGINE."
                 )
-    
+
     @classmethod
     def disable_rls(cls) -> None:
         """Disable RLS for this model's table."""
         from django.db import connections
-        
+
         # Models don't have _state, use default connection
-        db_alias = 'default'
+        db_alias = "default"
         connection = connections[db_alias]
-        
+
         with connection.schema_editor() as schema_editor:
-            if hasattr(schema_editor, 'disable_rls'):
+            if hasattr(schema_editor, "disable_rls"):
                 # Drop policies
                 for policy in cls._rls_policies:
                     schema_editor.drop_policy(cls, policy.name)
-                
+
                 # Disable RLS
                 schema_editor.disable_rls(cls)
-                
+
                 logger.info(f"RLS disabled for {cls._meta.db_table}")
             else:
                 logger.warning(
@@ -131,13 +136,17 @@ class RLSModel(models.Model, metaclass=RLSModelMeta):
 def enable_rls_on_migrate(sender, **kwargs):
     """Enable RLS after migrations."""
     # Only process models from the migrated app
-    if sender.name == 'django_rls':
+    if sender.name == "django_rls":
         return
-        
+
     from django.apps import apps
-    
+
     for model in apps.get_models():
-        if issubclass(model, RLSModel) and hasattr(model, '_rls_policies') and model._rls_policies:
+        if (
+            issubclass(model, RLSModel)
+            and hasattr(model, "_rls_policies")
+            and model._rls_policies
+        ):
             if model._meta.app_label == sender.name:
                 try:
                     model.enable_rls()

--- a/tests/audit/test_complex_queries.py
+++ b/tests/audit/test_complex_queries.py
@@ -1,4 +1,3 @@
-
 """
 Audit Test III: Complex Queries & Joins
 
@@ -6,57 +5,60 @@ Focuses on:
 - Cross-Table Joins (The "Trojan Horse"): RLS Table JOIN Reference Table.
 - Subquery Context Propagation.
 """
-from django.test import TransactionTestCase
 from django.contrib.auth.models import User
-from django.db.models import Subquery, OuterRef
-from tests.models import UserOwnedModel, Organization, SimpleModel
+from django.db.models import Subquery
+from django.test import TransactionTestCase
+
+from django_rls.db.functions import RLSContext
+from tests.models import SimpleModel, UserOwnedModel
+
 
 class TestComplexQueries(TransactionTestCase):
-    
     def setUp(self):
         self.u1 = User.objects.create_user("u1")
         self.ref_data = SimpleModel.objects.create(name="Public Ref")
-        self.u1_data = UserOwnedModel.objects.create(title="My Data", content="x", owner=self.u1)
+        with RLSContext(user_id=self.u1.id):
+            self.u1_data = UserOwnedModel.objects.create(
+                title="My Data", content="x", owner=self.u1
+            )
 
     def test_trojan_horse_join(self):
         """
-        Scenario: Joining a filtered table (RLS enabled) with a non-filtered table (Reference data).
-        Check: Ensure the join condition doesn't inadvertently bypass the filter on the RLS table.
-        
-        Example: 
+        Scenario: Joining a filtered table (RLS enabled) with a non-filtered
+        table (Reference data).
+        Check: Ensure the join condition doesn't inadvertently bypass the
+        filter on the RLS table.
+
+        Example:
         UserOwnedModel.objects.filter(reference__name="Public Ref")
         If 'reference' was a FK to SimpleModel.
-        
-        We don't have a direct FK from RLS model to SimpleModel in tests/models.py currently.
-        But we can simulate a cross-join or implicit join.
-        
+
+        We don't have a direct FK from RLS model to SimpleModel in
+        tests/models.py currently. But we can simulate a cross-join or
+        implicit join.
+
         If we query the *Public* table and prefetch the *Private* table?
         """
         # Scenario: SimpleModel (No RLS) -> join -> UserOwnedModel (RLS).
         # Since no FK exists, we can't do implicit join easily.
-        # But conceptually:
-        # qs = SimpleModel.objects.annotate(
-        #    user_data=Subquery(UserOwnedModel.objects.filter(owner=OuterRef('...')))
-        # )
-        
+
         # Test: Subquery on RLS model should still generate RLS clauses.
-        # We can inspect the query or trust our previous Extensive tests.
-        
-        subq = UserOwnedModel.objects.filter(pk=self.u1_data.pk).values('title')
-        qs = SimpleModel.objects.annotate(
-            private_title=Subquery(subq[:1])
-        )
-        # When generated SQL runs:
-        # SELECT ..., (SELECT U0."title" FROM "tests_userownedmodel" U0 WHERE U0."id" = ... AND rls_clause) ...
-        
-        # In SQLite (mocked), we just ensure it builds without error.
-        assert qs.exists()
+
+        with RLSContext(user_id=self.u1.id):
+            subq = UserOwnedModel.objects.filter(pk=self.u1_data.pk).values("title")
+            qs = SimpleModel.objects.annotate(private_title=Subquery(subq[:1]))
+            # When generated SQL runs, RLS clause is applied in subquery
+
+            # Ensure it builds and executes without error.
+            assert qs.exists()
 
     def test_cte_recursion_security(self):
         """
         Scenario: CTE recursion.
-        If strict security needed, verify recursion stops if permissions revoked deep in tree.
-        This is hard to test in Django ORM (no native CTE support without 3rd party or raw SQL).
+        If strict security needed, verify recursion stops if permissions
+        revoked deep in tree.
+        This is hard to test in Django ORM (no native CTE support without
+        3rd party or raw SQL).
         We mark this as 'Audit: Manual Review Required for Raw SQL'.
         """
         pass

--- a/tests/audit/test_leakage.py
+++ b/tests/audit/test_leakage.py
@@ -1,81 +1,75 @@
-
 """
 Audit Test II: Leakage & Security Vulnerabilities
 
 Focuses on side-channel leaks and standard RLS bypass techniques.
 """
-from django.test import TransactionTestCase
 from django.contrib.auth.models import User
 from django.db import IntegrityError, transaction
-from django.conf import settings
-from tests.models import UserOwnedModel, TenantModel, Organization
+from django.test import TransactionTestCase
+
+from django_rls.db.functions import RLSContext
+from tests.models import Organization, UserOwnedModel
+
 
 class TestLeakage(TransactionTestCase):
-    
     def setUp(self):
         self.u1 = User.objects.create_user("u1")
         self.u2 = User.objects.create_user("u2")
         self.org1 = Organization.objects.create(name="org1", slug="org1")
-        
+
         # User 2 creates a row that U1 shouldn't see
-        self.hidden_obj = UserOwnedModel.objects.create(
-            title="Hidden", content="data", owner=self.u2
-        )
-        self.hidden_id = self.hidden_obj.id
+        with RLSContext(user_id=self.u2.id):
+            self.hidden_obj = UserOwnedModel.objects.create(
+                title="Hidden", content="data", owner=self.u2
+            )
+            self.hidden_id = self.hidden_obj.id
 
     def test_update_blindside(self):
         """
         Scenario: User A runs UPDATE table SET val=X WHERE id=HiddenID.
         Check: The operation must report 0 rows affected, and NOT throw specific errors.
         """
-        # In Django ORM:
-        # UserOwnedModel.objects.filter(id=self.hidden_id).update(title="Hacked")
-        # With active RLS (mocked logic), this filter would effectively be:
-        # WHERE id=HiddenID AND owner_id = U1
-        
-        # Simulating the RLS condition:
-        # Since we use SQLite, we manually verify that .filter() logic produces 0 rows
-        # if the RLS clause is assumed to be active.
-        # But wait, we can just test that attempting to update *without* ownership logic fails if RLS was enforcing it.
-        # Actually, in a TransactionTestCase without Postgres RLS, we can only test the *principle*.
-        
-        # Code check:
-        # `update()` returns number of rows matched.
-        qs = UserOwnedModel.objects.filter(id=self.hidden_id)
-        # If RLS is applied, this QS should be empty for U1.
-        # Since we can't apply RLS in SQLite, we verify that *Django* doesn't leak info if it returns 0.
-        
-        count = qs.update(title="Hacked")
-        # In SQLite, this will be 1 because RLS isn't actually filtering.
-        # To assert the *behavior we want*, we must acknowledge the environment.
-        # Assert: If the QS *were* filtered (as RLS would do), count is 0.
-        # This test documents the expectation.
-        pass
+        # With RLS enforced, User 1 trying to update User 2's row should affect 0 rows
+        with RLSContext(user_id=self.u1.id):
+            qs = UserOwnedModel.objects.filter(id=self.hidden_id)
+            count = qs.update(title="Hacked")
+            # RLS filters out the row, so 0 rows affected
+            assert count == 0
+
+        # Verify the row was not changed
+        with RLSContext(user_id=self.u2.id):
+            obj = UserOwnedModel.objects.get(id=self.hidden_id)
+            assert obj.title == "Hidden"  # Unchanged
 
     def test_existence_leak_insert_duplicate(self):
         """
         Scenario: Insert a row with a PK that already exists (but is hidden).
         Expected: Database error (IntegrityError: Unique Violation).
-        
-        In Postgres, does this leak existence? Yes, "Key (id)=(X) already exists."
-        RLS does NOT hide the Primary Key uniqueness constraint unless using `ON CONFLICT`.
-        
-        This is a KNOWN leak in Postgres RLS unless partitioned or UUIDs used.
-        We verify that Django propagates the standard IntegrityError.
+
+        In Postgres, does this leak existence? Yes, "Key (id)=(X) already
+        exists." RLS does NOT hide the Primary Key uniqueness constraint
+        unless using `ON CONFLICT`.
+
+        This is a KNOWN leak in Postgres RLS unless partitioned or UUIDs
+        used. We verify that Django propagates the standard IntegrityError.
         """
-        try:
-            with transaction.atomic():
-                UserOwnedModel(id=self.hidden_id, title="Clash", content="x", owner=self.u1).save(force_insert=True)
-            # If we succeed, it means ID collision didn't happen (impossible) or we overwrote (bad).
-        except IntegrityError:
-            # This confirms that constraints fire regardless of RLS visibility.
-            # This IS a side-channel (checking if ID 5 exists), but unavoidable in standard SQL 
-            # without logic changes (e.g. random UUIDs).
-            pass
+        with RLSContext(user_id=self.u1.id):
+            try:
+                with transaction.atomic():
+                    UserOwnedModel(
+                        id=self.hidden_id, title="Clash", content="x", owner=self.u1
+                    ).save(force_insert=True)
+                # If we succeed, ID collision didn't happen or we overwrote.
+                assert False, "Should have raised IntegrityError"
+            except IntegrityError:
+                # Confirms that constraints fire regardless of RLS visibility.
+                # This IS a side-channel but unavoidable in standard SQL
+                # without logic changes (e.g. random UUIDs).
+                pass
 
     def test_aggregate_leakage(self):
         """
-        Scenario: Count(*) 
+        Scenario: Count(*)
         Check: Returns count of visible rows only.
         """
         # Already covered in tests/extensive/test_query_patterns.py
@@ -85,7 +79,7 @@ class TestLeakage(TransactionTestCase):
         """
         Scenario: Insert a row we own, but maybe trigger modifies it?
         Or Insert row we DON'T own (if policy allows).
-        If I insert a row for User 2 (as User 1) - if policy allows insert but not select?
-        Then logic should prevent `returning`.
+        If I insert a row for User 2 (as User 1) - if policy allows insert
+        but not select? Then logic should prevent `returning`.
         """
         pass

--- a/tests/models.py
+++ b/tests/models.py
@@ -115,7 +115,8 @@ class HierarchyData(RLSModel):
                 "manager_access",
                 expression=(
                     "owner_id IN (SELECT subordinate_id FROM tests_userhierarchy "
-                    "WHERE manager_id = current_setting('rls.user_id')::int)"
+                    "WHERE manager_id = "
+                    "NULLIF(current_setting('rls.user_id', true), '')::int)"
                 ),
             ),
         ]
@@ -177,16 +178,19 @@ class ERPDocument(RLSModel):
             # )
             CustomPolicy(
                 "hierarchy_policy",
-                expression="department_id IN ("
-                "WITH RECURSIVE dept_tree AS ("
-                "    SELECT id FROM tests_department "
-                "    WHERE id = current_setting('rls.tenant_id')::int "
-                "    UNION "
-                "    SELECT d.id FROM tests_department d "
-                "    INNER JOIN dept_tree dt ON d.parent_id = dt.id "
-                ") "
-                "SELECT id FROM dept_tree"
-                ")",
+                expression=(
+                    "department_id IN ("
+                    "WITH RECURSIVE dept_tree AS ("
+                    "    SELECT id FROM tests_department "
+                    "    WHERE id = "
+                    "NULLIF(current_setting('rls.tenant_id', true), '')::int "
+                    "    UNION "
+                    "    SELECT d.id FROM tests_department d "
+                    "    INNER JOIN dept_tree dt ON d.parent_id = dt.id "
+                    ") "
+                    "SELECT id FROM dept_tree"
+                    ")"
+                ),
             ),
             # 2. ACL Policy:
             # Visible if User has explicit entry in UserPermission for this doc.
@@ -196,10 +200,13 @@ class ERPDocument(RLSModel):
             # )
             CustomPolicy(
                 "acl_policy",
-                expression="id IN ("
-                "    SELECT document_id FROM tests_userpermission "
-                "    WHERE user_id = current_setting('rls.user_id')::int "
-                "    AND can_view = true"
-                ")",
+                expression=(
+                    "id IN ("
+                    "    SELECT document_id FROM tests_userpermission "
+                    "    WHERE user_id = "
+                    "NULLIF(current_setting('rls.user_id', true), '')::int "
+                    "    AND can_view = true"
+                    ")"
+                ),
             ),
         ]

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -135,7 +135,7 @@ class TestCustomPolicy(TestCase):
     def test_complex_custom_expression(self):
         """Test complex custom expressions."""
         expression = """
-        (user_id = current_setting('rls.user_id')::integer
+        (user_id = NULLIF(current_setting('rls.user_id', true), '')::integer
          OR is_public = true)
         AND NOT is_deleted
         """

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -246,7 +246,7 @@ class TestAuthenticationBypass(TestCase):
         policy_expression = """
         EXISTS (
             SELECT 1 FROM auth_user u
-            WHERE u.id = current_setting('rls.user_id')::integer
+            WHERE u.id = NULLIF(current_setting('rls.user_id', true), '')::integer
             AND u.is_superuser = false
         )
         """
@@ -379,16 +379,16 @@ class TestPolicyValidation(TestCase):
         """Test handling of complex policy expressions."""
         # Complex nested expression
         complex_expr = """
-        (user_id = current_setting('rls.user_id')::integer
+        (user_id = NULLIF(current_setting('rls.user_id', true), '')::integer
         OR EXISTS (
             SELECT 1 FROM permissions p
-            WHERE p.user_id = current_setting('rls.user_id')::integer
+            WHERE p.user_id = NULLIF(current_setting('rls.user_id', true), '')::integer
             AND p.resource_id = id
         ))
         AND NOT deleted
         AND (
             is_public = true
-            OR owner_id = current_setting('rls.user_id')::integer
+            OR owner_id = NULLIF(current_setting('rls.user_id', true), '')::integer
         )
         """
 


### PR DESCRIPTION
## Summary

- Adds `FORCE ROW LEVEL SECURITY` after `ENABLE ROW LEVEL SECURITY` to ensure RLS policies are enforced even for the table owner
- Fixes test models to use `current_setting(..., true)` with `missing_ok=true` in CustomPolicy expressions
- Updates tests to properly set RLS context using `RLSContext` before creating/querying RLS-protected data

## Problem

PostgreSQL RLS policies don't apply to the table owner by default. Since Django typically connects as the user who created the tables (the owner), RLS was being silently bypassed. This caused the issue reported on the forum where RLS wasn't working in the admin panel.

## Solution

Added `schema_editor.force_rls(cls)` call in `enable_rls()` method to execute `ALTER TABLE ... FORCE ROW LEVEL SECURITY`, which ensures policies are enforced regardless of the database user.

## Test plan

- [x] All 120 tests pass
- [x] Tests now properly verify RLS enforcement (previously were false positives)
- [x] Tests use `RLSContext` to set context before operations on RLS-protected tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)