### PR TITLE
fix(rls_config): use auto_enable_rls in migrate signal

### DIFF
--- a/django_rls/models.py
+++ b/django_rls/models.py
@@ -139,6 +139,11 @@ def enable_rls_on_migrate(sender, **kwargs):
     if sender.name == "django_rls":
         return
 
+    from django_rls.conf import rls_config
+
+    if not rls_config.auto_enable_rls:
+        return
+
     from django.apps import apps
 
     for model in apps.get_models():

--- a/tests/integration/test_configuration.py
+++ b/tests/integration/test_configuration.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
@@ -10,15 +10,9 @@ from django.test import override_settings
 def test_enable_rls_enabled_on_migrate():
     from django_rls.models import RLSModel
 
-    original_enable_rls = RLSModel.enable_rls
-    enable_rls = MagicMock()
-    RLSModel.enable_rls = enable_rls
-
-    call_command("migrate")
-
-    enable_rls.assert_called()
-
-    RLSModel.enable_rls = original_enable_rls
+    with patch.object(RLSModel, "enable_rls") as enable_rls:
+        call_command("migrate")
+        enable_rls.assert_called()
 
 
 @override_settings(DJANGO_RLS={"AUTO_ENABLE_RLS": False})
@@ -26,12 +20,6 @@ def test_enable_rls_enabled_on_migrate():
 def test_enable_rls_disabled_on_migrate():
     from django_rls.models import RLSModel
 
-    original_enable_rls = RLSModel.enable_rls
-    enable_rls = MagicMock()
-    RLSModel.enable_rls = enable_rls
-
-    call_command("migrate")
-
-    enable_rls.assert_not_called()
-
-    RLSModel.enable_rls = original_enable_rls
+    with patch.object(RLSModel, "enable_rls") as enable_rls:
+        call_command("migrate")
+        enable_rls.assert_not_called()

--- a/tests/integration/test_configuration.py
+++ b/tests/integration/test_configuration.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+
+
+@override_settings(DJANGO_RLS={"AUTO_ENABLE_RLS": True})
+@pytest.mark.django_db
+def test_enable_rls_enabled_on_migrate():
+    from django_rls.models import RLSModel
+
+    original_enable_rls = RLSModel.enable_rls
+    enable_rls = MagicMock()
+    RLSModel.enable_rls = enable_rls
+
+    call_command("migrate")
+
+    enable_rls.assert_called()
+
+    RLSModel.enable_rls = original_enable_rls
+
+
+@override_settings(DJANGO_RLS={"AUTO_ENABLE_RLS": False})
+@pytest.mark.django_db
+def test_enable_rls_disabled_on_migrate():
+    from django_rls.models import RLSModel
+
+    original_enable_rls = RLSModel.enable_rls
+    enable_rls = MagicMock()
+    RLSModel.enable_rls = enable_rls
+
+    call_command("migrate")
+
+    enable_rls.assert_not_called()
+
+    RLSModel.enable_rls = original_enable_rls

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -106,7 +106,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Django RLS Settings
 DJANGO_RLS = {
-    'AUTO_ENABLE_RLS': False,  # Don't auto-enable in tests
+    'AUTO_ENABLE_RLS': True,  # Tests rely on post_migrate to enable RLS on test tables
     'DEFAULT_ROLES': 'public',
     'DEFAULT_PERMISSIVE': True,
     'DEBUG': True,


### PR DESCRIPTION
## Description
This checks the `rls_config` before running the post migrate signal to appropriately check for the `auto_enable_rls` configuration.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issue
Fixes #51

## Changes Made

- adds a check in `enable_rls_on_migrate` with an early return is `auto_enable_rls` is False
- adds test cases

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Tested with PostgreSQL version: 17
- [x] Tested with Django version: 5.2.13

### Test Configuration
- **Python version**: 3.13
- **Django version**: 5.2.13
- **PostgreSQL version**: 17

## Security Checklist
<!-- Important for RLS-related changes -->

- [x] No SQL injection vulnerabilities introduced
- [x] RLS policies cannot be bypassed
- [x] Context isolation is maintained
- [x] No sensitive data exposed in logs/errors
- [x] Proper permission checks in place
- [x] Database privileges are correctly enforced

## Documentation
This feature is already documented.

## Performance Impact
Should be negligible because this change is isolated to the post migrate signal.

## Checklist
<!-- Ensure all items are checked before submitting -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published