### PR TITLE
perf: wrap policy context reads in scalar subquery (InitPlan)

### DIFF
--- a/django_rls/policies.py
+++ b/django_rls/policies.py
@@ -94,11 +94,17 @@ class TenantPolicy(BasePolicy):
         self.validate_field_name(self.tenant_field)
 
     def get_sql_expression(self) -> str:
-        """Generate SQL expression for tenant-based filtering."""
+        """Generate SQL expression for tenant-based filtering.
+
+        The ``current_setting`` read is wrapped in a scalar subquery so the
+        planner evaluates it once per statement (an InitPlan) instead of once
+        per candidate row. This is the documented Postgres RLS performance
+        pattern and is predicate-equivalent to the bare call.
+        """
         return (
             f"{self.tenant_field}_id = "
-            f"NULLIF(current_setting('rls.tenant_id', true), '') "
-            ":: integer"  # noqa: E231
+            f"(SELECT NULLIF(current_setting('rls.tenant_id', true), '') "
+            ":: integer)"  # noqa: E231
         )
 
 
@@ -116,10 +122,17 @@ class UserPolicy(BasePolicy):
         self.validate_field_name(self.user_field)
 
     def get_sql_expression(self) -> str:
-        """Generate SQL expression for user-based filtering."""
+        """Generate SQL expression for user-based filtering.
+
+        The ``current_setting`` read is wrapped in a scalar subquery so the
+        planner evaluates it once per statement (an InitPlan) instead of once
+        per candidate row. This is the documented Postgres RLS performance
+        pattern and is predicate-equivalent to the bare call.
+        """
         return (
             f"{self.user_field}_id = "
-            f"NULLIF(current_setting('rls.user_id', true), '') :: integer"  # noqa: E231
+            f"(SELECT NULLIF(current_setting('rls.user_id', true), '') "
+            ":: integer)"  # noqa: E231
         )
 
 

--- a/django_rls/policies.py
+++ b/django_rls/policies.py
@@ -172,16 +172,23 @@ class CurrentContext(Func):
     def as_postgresql(self, compiler, connection, **extra_context):
         # We handle casting explicitly in SQL for clarity
         sql, params = super().as_sql(compiler, connection, **extra_context)
+        # Wrap the context read in a scalar subquery so Postgres evaluates
+        # it once per statement (an InitPlan) instead of once per candidate
+        # row — the same per-statement caching the raw-string TenantPolicy/
+        # UserPolicy predicates use. This keeps ModelPolicy (which compiles
+        # Q objects through this expression) consistent with the other
+        # policy types. Predicate-equivalent: a scalar subquery returns the
+        # same single value.
         if isinstance(self.output_field, IntegerField):
-            return f"({sql}) :: integer", params  # noqa: E231
+            return f"(SELECT ({sql}) :: integer)", params  # noqa: E231
 
         from django.db.models import UUIDField
 
         if isinstance(self.output_field, UUIDField):
-            return f"({sql}) :: uuid", params  # noqa: E231
+            return f"(SELECT ({sql}) :: uuid)", params  # noqa: E231
 
         # Text doesn't need implicit cast usually, but safe to leave as string
-        return sql, params
+        return f"(SELECT {sql})", params
 
 
 class UserContext(CurrentContext):

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -61,8 +61,9 @@ class TestTenantPolicy(TestCase):
 
         sql = policy.get_sql_expression()
         assert (
-            sql == "company_id = NULLIF(current_setting('rls.tenant_id', true), '') "
-            ":: integer"
+            sql == "company_id = "
+            "(SELECT NULLIF(current_setting('rls.tenant_id', true), '') "
+            ":: integer)"
         )
 
     def test_tenant_policy_requires_field(self):
@@ -98,8 +99,9 @@ class TestUserPolicy(TestCase):
         assert policy.user_field == "owner"
         sql = policy.get_sql_expression()
         assert (
-            sql
-            == "owner_id = NULLIF(current_setting('rls.user_id', true), '') :: integer"
+            sql == "owner_id = "
+            "(SELECT NULLIF(current_setting('rls.user_id', true), '') "
+            ":: integer)"
         )
 
     def test_user_policy_expressions(self):

--- a/tests/test_pythonic_policies.py
+++ b/tests/test_pythonic_policies.py
@@ -93,10 +93,15 @@ class TestPythonicPolicies(TransactionTestCase):
                 """
                 )
                 expr = cursor.fetchone()[0]
-                # Expected:
-                # owner_id = NULLIF(current_setting('rls.user_id', true), '')::integer
+                # Expected (context read wrapped in a scalar subquery so the
+                # planner evaluates it once per statement as an InitPlan):
+                #   owner_id = (SELECT NULLIF(current_setting('rls.user_id', true), '')::integer)
                 assert "rls.user_id" in expr
                 assert "current_setting" in expr
+                assert "select" in expr.lower(), (
+                    "context read must be wrapped in a scalar subquery "
+                    "(InitPlan); got: " + expr
+                )
 
         finally:
             with connection.schema_editor() as schema_editor:

--- a/tests/test_schema_editor.py
+++ b/tests/test_schema_editor.py
@@ -70,8 +70,9 @@ class TestRLSDatabaseSchemaEditor(TestCase):
         assert "FOR ALL" in call_args
         assert "TO public" in call_args
         assert (
-            "USING (owner_id = NULLIF(current_setting('rls.user_id', true), '') "
-            ":: integer)" in call_args
+            "USING (owner_id = "
+            "(SELECT NULLIF(current_setting('rls.user_id', true), '') "
+            ":: integer))" in call_args
         )
 
     def test_create_tenant_policy(self):
@@ -85,8 +86,9 @@ class TestRLSDatabaseSchemaEditor(TestCase):
 
         call_args = self.editor.execute.call_args[0][0]
         assert (
-            "USING (organization_id = NULLIF(current_setting('rls.tenant_id', true), '') "
-            ":: integer)" in call_args
+            "USING (organization_id = "
+            "(SELECT NULLIF(current_setting('rls.tenant_id', true), '') "
+            ":: integer))" in call_args
         )
 
     def test_create_custom_policy(self):


### PR DESCRIPTION
TenantPolicy and UserPolicy emitted a bare current_setting() call in the USING/WITH CHECK predicate, e.g.

  tenant_id = NULLIF(current_setting('rls.tenant_id', true), '')::integer

Postgres evaluates that call once per candidate row. Wrapping it in a scalar subquery lets the planner cache the value as an InitPlan that runs once per statement:

  tenant_id = (SELECT NULLIF(current_setting('rls.tenant_id', true), '')::integer)

This is the documented Postgres RLS performance pattern (also recommended in Supabase's RLS performance guide). The rewrite is predicate-equivalent: a scalar subquery returning a single value compares identically, and an unauthenticated session still yields NULL (fail-closed).

Verified on PostgreSQL 17 against the exact DDL the backend emits: tenant=N sees only its rows, a different tenant sees none, and an unset context sees none — identical for the bare and wrapped forms.

Addresses sub-item 2 of #53. (Sub-item 1, TO-scoped policies, is already implemented: the backend emits `TO %(roles)s` and policies accept `roles=`.)

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Please delete options that are not relevant -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring
- [ ] 🔒 Security fix

## Related Issue
<!-- Please link to the issue here -->
Fixes #53 

## Changes Made
<!-- List the main changes made in this PR -->

- 
- 
- 

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [ ] Tested with PostgreSQL version: <!-- specify version -->
- [ ] Tested with Django version: <!-- specify version -->
- [x] Manual testing completed

### Test Configuration
- **Python version**:
- **Django version**:
- **PostgreSQL version**:

## Security Checklist
<!-- Important for RLS-related changes -->

- [x] No SQL injection vulnerabilities introduced
- [x] RLS policies cannot be bypassed
- [x] Context isolation is maintained
- [x] No sensitive data exposed in logs/errors
- [x] Proper permission checks in place
- [x] Database privileges are correctly enforced

## Documentation
<!-- Check all that apply -->

- [ ] Code includes inline documentation
- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [ ] Migration guide provided (for breaking changes)

## Performance Impact
<!-- Describe any performance implications -->

- [ ] Database queries optimized
- [ ] No N+1 query problems
- [ ] RLS policies are efficient
- [ ] Benchmarks run (if applicable)

## Checklist
<!-- Ensure all items are checked before submitting -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->