### PR TITLE
chore(deps): tune dependabot to stop range-widening and group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,12 @@ updates:
       interval: "weekly"
     reviewers:
       - "kdpisda"
-  
+    # Collapse action bumps into a single PR instead of one per action
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
   # Maintain dependencies for Python
   - package-ecosystem: "pip"
     directory: "/"
@@ -15,7 +20,16 @@ updates:
       interval: "weekly"
     reviewers:
       - "kdpisda"
-  
+    # Bump the pin only when a release falls outside the existing constraint,
+    # rather than widening caret ranges to allow future majors in unreviewed.
+    versioning-strategy: "increase-if-necessary"
+    # One grouped PR for runtime deps, one for dev tooling
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+
   # Maintain dependencies for npm (documentation)
   - package-ecosystem: "npm"
     directory: "/documentations"
@@ -26,3 +40,8 @@ updates:
     # Limit to documentation-related updates
     allow:
       - dependency-type: "all"
+    # Collapse doc dependency bumps into a single PR
+    groups:
+      documentation-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What
Tune `.github/dependabot.yml`:
- **pip**: add `versioning-strategy: increase-if-necessary` so Dependabot bumps the pinned version only when a release falls outside the existing constraint, instead of widening caret pins.
- **Grouping**: collapse updates into one PR per concern — GitHub Actions, runtime (pip production) deps, dev tooling (pip development) deps, and docs (npm).

## Why
Dependabot's default pip strategy *widens* caret ranges (e.g. `black ^25.1.0` → `>=25.1,<27`). That doesn't upgrade anything in use — it only loosens dev-tool constraints so a future major (a reformatting `black`, a stricter `mypy`) can land unreviewed on a routine `poetry update`. For a library we'd rather keep dev tooling caret-pinned. This produced four such PRs (#60–63, now closed) plus four separate action PRs (#56–59, merged).

## How to test
- Dependabot validates the config on push; check the repo's **Insights → Dependency graph → Dependabot** tab shows no config errors.
- Next weekly run should open grouped PRs and no longer open range-widening PRs.

## Risk / rollback
Config-only, no runtime impact. Rollback = revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)