### PR TITLE
fix: gate USING/WITH CHECK clauses by policy operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Invalid `WITH CHECK` clause on SELECT/DELETE policies** — `RLSDatabaseSchemaEditor`
+  now gates `USING`/`WITH CHECK` clause generation on `policy.operation`, matching
+  PostgreSQL's rules (SELECT/DELETE: `USING` only; INSERT: `WITH CHECK` only;
+  UPDATE/ALL: both). Previously, `ModelPolicy` (and any policy compiled via
+  `get_compiled_sql`) emitted both clauses regardless of operation, causing Postgres
+  to reject `SELECT`/`DELETE` policies with "WITH CHECK cannot be applied to SELECT
+  or DELETE". `BasePolicy.get_using_expression()` is likewise now omitted for
+  `INSERT`-only policies. (#72)
+
 ## [1.0.0] - 2026-07-13
 
 Major security release. **Not backward compatible** with 0.4.x for apps that relied on

--- a/django_rls/backends/postgresql/base.py
+++ b/django_rls/backends/postgresql/base.py
@@ -68,27 +68,35 @@ class RLSDatabaseSchemaEditor(DatabaseSchemaEditor):
         wants_using = operation not in self.KNOWN_OPERATIONS or operation in self.USING_OPERATIONS
         wants_check = operation not in self.KNOWN_OPERATIONS or operation in self.CHECK_OPERATIONS
 
+        # ModelPolicy compiles the same Q object for both clauses. Compiling
+        # a Query (filter rewriting + running the SQL compiler) is
+        # expensive, so do it at most once and reuse the result rather than
+        # calling get_compiled_sql() twice for UPDATE/ALL policies.
+        compiled_sql = None
+        if (wants_using or wants_check) and hasattr(policy, "get_compiled_sql"):
+            compiled_sql = policy.get_compiled_sql(model)
+
         using_clause = ""
         if wants_using:
-            expr = None
-            # Model-aware compilation (ModelPolicy) takes priority.
             if hasattr(policy, "get_compiled_sql"):
-                expr = policy.get_compiled_sql(model)
+                expr = compiled_sql
             elif hasattr(policy, "get_using_expression"):
                 expr = policy.get_using_expression()
             elif hasattr(policy, "get_sql_expression"):
                 expr = policy.get_sql_expression()
+            else:
+                expr = None
             if expr:
                 using_clause = f"USING ({expr})"
 
         check_clause = ""
         if wants_check:
-            expr = None
-            # ModelPolicy uses the same compiled filter for the check clause.
             if hasattr(policy, "get_compiled_sql"):
-                expr = policy.get_compiled_sql(model)
+                expr = compiled_sql
             elif hasattr(policy, "get_check_expression"):
                 expr = policy.get_check_expression()
+            else:
+                expr = None
             if expr:
                 check_clause = f"WITH CHECK ({expr})"
 

--- a/django_rls/backends/postgresql/base.py
+++ b/django_rls/backends/postgresql/base.py
@@ -7,6 +7,18 @@ from django.db.backends.postgresql.schema import DatabaseSchemaEditor
 class RLSDatabaseSchemaEditor(DatabaseSchemaEditor):
     """Custom schema editor that supports RLS operations."""
 
+    # PostgreSQL restricts which clauses a CREATE/ALTER POLICY may carry,
+    # based on the policy's FOR <operation>:
+    #   SELECT / DELETE -> USING only
+    #   INSERT           -> WITH CHECK only
+    #   UPDATE / ALL     -> both USING and WITH CHECK
+    # An operation value we don't recognize (e.g. a test double that never
+    # set `.operation`) is treated permissively, generating both clauses,
+    # matching the previous unconditional behavior.
+    USING_OPERATIONS = {"SELECT", "UPDATE", "DELETE", "ALL"}
+    CHECK_OPERATIONS = {"INSERT", "UPDATE", "ALL"}
+    KNOWN_OPERATIONS = USING_OPERATIONS | CHECK_OPERATIONS
+
     sql_enable_rls = "ALTER TABLE %(table)s ENABLE ROW LEVEL SECURITY"
     sql_disable_rls = "ALTER TABLE %(table)s DISABLE ROW LEVEL SECURITY"
     sql_force_rls = "ALTER TABLE %(table)s FORCE ROW LEVEL SECURITY"
@@ -43,40 +55,50 @@ class RLSDatabaseSchemaEditor(DatabaseSchemaEditor):
         table_name = model._meta.db_table
         self.execute(self.sql_force_rls % {"table": self.quote_name(table_name)})
 
-    def create_policy(self, model, policy):
-        """Create an RLS policy."""
-        table_name = model._meta.db_table
+    def _build_clauses(self, policy, model):
+        """Build the USING and WITH CHECK clauses for a policy.
 
-        # Build the SQL components
-        # Build the SQL components
+        Clause generation is gated on ``policy.operation`` here — the single
+        place both ``create_policy`` and ``alter_policy`` go through — so an
+        operation that PostgreSQL doesn't allow a given clause for (e.g.
+        WITH CHECK on a SELECT policy) never reaches the generated DDL.
+        See issue #72.
+        """
+        operation = getattr(policy, "operation", None)
+        wants_using = operation not in self.KNOWN_OPERATIONS or operation in self.USING_OPERATIONS
+        wants_check = operation not in self.KNOWN_OPERATIONS or operation in self.CHECK_OPERATIONS
+
         using_clause = ""
-
-        # New: Check for model-aware compilation (ModelPolicy)
-        if hasattr(policy, "get_compiled_sql"):
-            expr = policy.get_compiled_sql(model)
-            if expr:
-                using_clause = f"USING ({expr})"
-        elif hasattr(policy, "get_using_expression"):
-            expr = policy.get_using_expression()
-            if expr:
-                using_clause = f"USING ({expr})"
-        elif hasattr(policy, "get_sql_expression"):
-            expr = policy.get_sql_expression()
+        if wants_using:
+            expr = None
+            # Model-aware compilation (ModelPolicy) takes priority.
+            if hasattr(policy, "get_compiled_sql"):
+                expr = policy.get_compiled_sql(model)
+            elif hasattr(policy, "get_using_expression"):
+                expr = policy.get_using_expression()
+            elif hasattr(policy, "get_sql_expression"):
+                expr = policy.get_sql_expression()
             if expr:
                 using_clause = f"USING ({expr})"
 
         check_clause = ""
+        if wants_check:
+            expr = None
+            # ModelPolicy uses the same compiled filter for the check clause.
+            if hasattr(policy, "get_compiled_sql"):
+                expr = policy.get_compiled_sql(model)
+            elif hasattr(policy, "get_check_expression"):
+                expr = policy.get_check_expression()
+            if expr:
+                check_clause = f"WITH CHECK ({expr})"
 
-        # New: Check for model-aware compilation (ModelPolicy)
-        if hasattr(policy, "get_compiled_sql"):
-            # ModelPolicy uses same filter for check
-            expr = policy.get_compiled_sql(model)
-            if expr:
-                check_clause = f"WITH CHECK ({expr})"
-        elif hasattr(policy, "get_check_expression"):
-            expr = policy.get_check_expression()
-            if expr:
-                check_clause = f"WITH CHECK ({expr})"
+        return using_clause, check_clause
+
+    def create_policy(self, model, policy):
+        """Create an RLS policy."""
+        table_name = model._meta.db_table
+
+        using_clause, check_clause = self._build_clauses(policy, model)
 
         sql = self.sql_create_policy % {
             "name": self.quote_name(policy.name),
@@ -107,25 +129,7 @@ class RLSDatabaseSchemaEditor(DatabaseSchemaEditor):
         """Alter an existing RLS policy."""
         table_name = model._meta.db_table
 
-        using_clause = ""
-        if hasattr(policy, "get_compiled_sql"):
-            expr = policy.get_compiled_sql(model)
-            if expr:
-                using_clause = f"USING ({expr})"
-        elif hasattr(policy, "get_using_expression"):
-            expr = policy.get_using_expression()
-            if expr:
-                using_clause = f"USING ({expr})"
-
-        check_clause = ""
-        if hasattr(policy, "get_compiled_sql"):
-            expr = policy.get_compiled_sql(model)
-            if expr:
-                check_clause = f"WITH CHECK ({expr})"
-        elif hasattr(policy, "get_check_expression"):
-            expr = policy.get_check_expression()
-            if expr:
-                check_clause = f"WITH CHECK ({expr})"
+        using_clause, check_clause = self._build_clauses(policy, model)
 
         self.execute(
             self.sql_alter_policy

--- a/django_rls/policies.py
+++ b/django_rls/policies.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
 from django.contrib.auth import get_user_model
-from django.db.models import CharField, Func, IntegerField, Q, Value
+from django.db.models import BooleanField, CharField, Func, IntegerField, Q, Value
 from django.db.models.sql import Query
 
 from django_rls.exceptions import PolicyError
@@ -252,6 +252,9 @@ class CurrentContext(Func):
         # same single value.
         if isinstance(self.output_field, IntegerField):
             return f"(SELECT ({sql}) :: integer)", params  # noqa: E231
+
+        if isinstance(self.output_field, BooleanField):
+            return f"(SELECT ({sql}) :: boolean)", params  # noqa: E231
 
         from django.db.models import UUIDField
 

--- a/django_rls/policies.py
+++ b/django_rls/policies.py
@@ -405,7 +405,10 @@ class ModelPolicy(BasePolicy):
                         # It is a ForeignKey (ManyToOne)
 
                         # Generate Subquery:
-                        # related_id IN (SELECT id FROM RelatedModel WHERE rest=value)
+                        # The FK column stores the target field value, which is
+                        # not necessarily the related model primary key.  For
+                        # example, ``ForeignKey(Game, to_field=\"ref\")`` stores
+                        # a UUID and must therefore select ``Game.ref``.
                         related_model = field.related_model
 
                         # Recursive rewrite?
@@ -415,7 +418,7 @@ class ModelPolicy(BasePolicy):
                         # target).
 
                         subquery = related_model.objects.filter(**{rest: value}).values(
-                            "pk"
+                            field.target_field.name
                         )
 
                         # Replace 'company__name' with 'company_id__in'

--- a/django_rls/policies.py
+++ b/django_rls/policies.py
@@ -111,11 +111,21 @@ class BasePolicy(ABC):
         pass
 
     def get_using_expression(self) -> Optional[str]:
-        """Return the USING clause expression (for SELECT/DELETE)."""
+        """Return the USING clause expression (for SELECT/UPDATE/DELETE/ALL).
+
+        PostgreSQL does not accept a USING clause on an INSERT-only policy,
+        so it is omitted for that operation (see issue #72).
+        """
+        if self.operation == self.INSERT:
+            return None
         return self.get_sql_expression()
 
     def get_check_expression(self) -> Optional[str]:
-        """Return the WITH CHECK clause expression (for INSERT/UPDATE)."""
+        """Return the WITH CHECK clause expression (for INSERT/UPDATE/ALL).
+
+        PostgreSQL does not accept a WITH CHECK clause on SELECT or DELETE
+        policies, so it is omitted for those operations (see issue #72).
+        """
         # By default, use the same expression as USING
         if self.operation in [self.INSERT, self.UPDATE, self.ALL]:
             return self.get_sql_expression()

--- a/tests/test_flexible_types.py
+++ b/tests/test_flexible_types.py
@@ -49,6 +49,16 @@ def test_current_context_generates_uuid_cast():
     assert "current_setting" in sql
 
 
+def test_current_context_generates_boolean_cast():
+    ctx = RLS.context("flag", output_field=models.BooleanField())
+    mock_compiler = MagicMock()
+    mock_compiler.compile = lambda x: ("%s", [])
+
+    sql, _ = ctx.as_postgresql(mock_compiler, MagicMock())
+
+    assert ":: boolean" in sql
+
+
 @pytest.mark.django_db
 def test_integration_uuid_field():
     """

--- a/tests/test_issue_14_joins.py
+++ b/tests/test_issue_14_joins.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from django.db import connection, models
 from django.db.models import Q
@@ -15,6 +17,7 @@ def test_joined_field_reference_error():
     """
 
     class Company(models.Model):
+        ref = models.UUIDField(default=uuid.uuid4, unique=True)
         name = models.CharField(max_length=100)
 
         class Meta:
@@ -23,7 +26,11 @@ def test_joined_field_reference_error():
 
     class Employee(RLSModel):
         name = models.CharField(max_length=100)
-        company = models.ForeignKey(Company, on_delete=models.CASCADE)
+        company = models.ForeignKey(
+            Company,
+            on_delete=models.CASCADE,
+            to_field="ref",
+        )
 
         class Meta:
             app_label = "tests"

--- a/tests/test_issue_72_invalid_check_clause.py
+++ b/tests/test_issue_72_invalid_check_clause.py
@@ -1,0 +1,214 @@
+"""
+Regression tests for Issue #72.
+
+``ModelPolicy(operation=SELECT)`` (and DELETE) emitted an invalid
+``WITH CHECK`` clause alongside ``USING``, which PostgreSQL rejects with
+"WITH CHECK cannot be applied to SELECT or DELETE". The root cause was that
+``RLSDatabaseSchemaEditor.create_policy``/``alter_policy`` called
+``policy.get_compiled_sql(model)`` unconditionally for both clauses whenever
+a policy exposed model-aware compilation (``ModelPolicy``), ignoring
+``policy.operation`` entirely.
+
+PostgreSQL's rules, per ``CREATE POLICY``:
+  * SELECT / DELETE -> USING only
+  * INSERT           -> WITH CHECK only
+  * UPDATE / ALL     -> both USING and WITH CHECK
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from django.db import connection, models
+from django.db.models import Q
+from django.test import TestCase
+
+from django_rls.backends.postgresql.base import RLSDatabaseSchemaEditor
+from django_rls.models import RLSModel
+from django_rls.policies import BasePolicy, ModelPolicy, UserPolicy
+
+# operation -> (expect USING clause, expect WITH CHECK clause)
+OPERATION_EXPECTATIONS = [
+    (BasePolicy.SELECT, True, False),
+    (BasePolicy.DELETE, True, False),
+    (BasePolicy.INSERT, False, True),
+    (BasePolicy.UPDATE, True, True),
+    (BasePolicy.ALL, True, True),
+]
+
+
+class _CountryModel(RLSModel):
+    """Real model needed by ModelPolicy.get_compiled_sql(), which compiles
+    an actual Django ``Query`` against the model's ``_meta`` (a Mock won't
+    do)."""
+
+    country = models.CharField(max_length=8)
+
+    class Meta:
+        app_label = "tests"
+        rls_policies = []
+
+
+class TestSchemaEditorClauseGatingForModelPolicy(TestCase):
+    """Unit-level coverage of the exact code path the issue reports.
+
+    ``ModelPolicy`` is the policy type that routes through
+    ``get_compiled_sql`` in the schema editor, which is where the clauses
+    were previously generated unconditionally.
+    """
+
+    def setUp(self):
+        self.editor = RLSDatabaseSchemaEditor(Mock())
+        self.editor.execute = Mock()
+        self.editor.quote_name = lambda x: f'"{x}"'
+        self.model = _CountryModel
+
+    def test_operations_produce_only_valid_clauses(self):
+        for operation, wants_using, wants_check in OPERATION_EXPECTATIONS:
+            with self.subTest(operation=operation):
+                policy = ModelPolicy(
+                    f"policy_{operation.lower()}",
+                    filters=Q(country="US"),
+                    operation=operation,
+                )
+                self.editor.execute.reset_mock()
+                self.editor.create_policy(self.model, policy)
+
+                sql = self.editor.execute.call_args[0][0]
+                assert (f"FOR {operation}" in sql), sql
+                assert ("USING (" in sql) is wants_using, sql
+                assert ("WITH CHECK (" in sql) is wants_check, sql
+
+    def test_alter_policy_also_gates_clauses(self):
+        policy = ModelPolicy(
+            "select_policy", filters=Q(country="US"), operation=BasePolicy.SELECT
+        )
+        self.editor.alter_policy(self.model, policy)
+
+        sql = self.editor.execute.call_args[0][0]
+        assert "USING (" in sql
+        assert "WITH CHECK (" not in sql
+
+
+class TestSchemaEditorClauseGatingForExpressionPolicy(TestCase):
+    """Same coverage for the get_using_expression/get_check_expression path
+    (e.g. UserPolicy, TenantPolicy, CustomPolicy)."""
+
+    def setUp(self):
+        self.editor = RLSDatabaseSchemaEditor(Mock())
+        self.editor.execute = Mock()
+        self.editor.quote_name = lambda x: f'"{x}"'
+        self.model = Mock()
+        self.model._meta.db_table = "test_table"
+
+    def test_operations_produce_only_valid_clauses(self):
+        for operation, wants_using, wants_check in OPERATION_EXPECTATIONS:
+            with self.subTest(operation=operation):
+                policy = UserPolicy(
+                    f"user_policy_{operation.lower()}",
+                    user_field="owner",
+                    operation=operation,
+                )
+                self.editor.execute.reset_mock()
+                self.editor.create_policy(self.model, policy)
+
+                sql = self.editor.execute.call_args[0][0]
+                assert ("USING (" in sql) is wants_using, sql
+                assert ("WITH CHECK (" in sql) is wants_check, sql
+
+
+class TestBasePolicyExpressionGating:
+    """BasePolicy.get_using_expression/get_check_expression should also be
+    gated on operation, independent of the schema editor."""
+
+    def test_get_using_expression_omitted_for_insert(self):
+        policy = UserPolicy("p", user_field="owner", operation=BasePolicy.INSERT)
+        assert policy.get_using_expression() is None
+        assert policy.get_check_expression() is not None
+
+    def test_get_check_expression_omitted_for_select(self):
+        policy = UserPolicy("p", user_field="owner", operation=BasePolicy.SELECT)
+        assert policy.get_using_expression() is not None
+        assert policy.get_check_expression() is None
+
+    def test_get_check_expression_omitted_for_delete(self):
+        policy = UserPolicy("p", user_field="owner", operation=BasePolicy.DELETE)
+        assert policy.get_using_expression() is not None
+        assert policy.get_check_expression() is None
+
+    def test_both_present_for_update_and_all(self):
+        for operation in (BasePolicy.UPDATE, BasePolicy.ALL):
+            policy = UserPolicy("p", user_field="owner", operation=operation)
+            assert policy.get_using_expression() is not None
+            assert policy.get_check_expression() is not None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_model_policy_ddl_is_accepted_by_postgres_for_every_operation():
+    """
+    End-to-end reproduction of the issue's repro case: creating RLS policies
+    for every operation must not raise
+    ``ProgrammingError: WITH CHECK cannot be applied to SELECT or DELETE``,
+    and PostgreSQL's own catalog must reflect only the applicable clauses.
+    """
+    if connection.vendor != "postgresql":
+        pytest.skip("Requires PostgreSQL")
+
+    class Document(RLSModel):
+        country = models.CharField(max_length=8)
+
+        class Meta:
+            app_label = "tests"
+            db_table = "issue72_document"
+            rls_policies = [
+                ModelPolicy(
+                    "select_by_country", filters=Q(country="US"), operation=BasePolicy.SELECT
+                ),
+                ModelPolicy(
+                    "delete_by_country", filters=Q(country="US"), operation=BasePolicy.DELETE
+                ),
+                ModelPolicy(
+                    "insert_by_country", filters=Q(country="US"), operation=BasePolicy.INSERT
+                ),
+                ModelPolicy(
+                    "update_by_country", filters=Q(country="US"), operation=BasePolicy.UPDATE
+                ),
+                ModelPolicy(
+                    "all_by_country", filters=Q(country="US"), operation=BasePolicy.ALL
+                ),
+            ]
+
+    with connection.schema_editor() as schema_editor:
+        schema_editor.create_model(Document)
+
+    try:
+        # Prior to the fix this raised:
+        # django.db.utils.ProgrammingError: WITH CHECK cannot be applied
+        # to SELECT or DELETE
+        Document.enable_rls()
+
+        # polcmd: 'r' = SELECT, 'a' = INSERT, 'w' = UPDATE, 'd' = DELETE,
+        # '*' = ALL. See https://www.postgresql.org/docs/current/catalog-pg-policy.html
+        expected = {
+            "select_by_country": ("r", True, False),
+            "delete_by_country": ("d", True, False),
+            "insert_by_country": ("a", False, True),
+            "update_by_country": ("w", True, True),
+            "all_by_country": ("*", True, True),
+        }
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT polname, polcmd, polqual IS NOT NULL, "
+                "polwithcheck IS NOT NULL FROM pg_policy "
+                "WHERE polname = ANY(%s)",
+                [list(expected)],
+            )
+            rows = {row[0]: (row[1], row[2], row[3]) for row in cursor.fetchall()}
+
+        assert set(rows) == set(expected)
+        for name, expectation in expected.items():
+            assert rows[name] == expectation, name
+
+    finally:
+        with connection.schema_editor() as schema_editor:
+            schema_editor.delete_model(Document)

--- a/tests/test_issue_72_invalid_check_clause.py
+++ b/tests/test_issue_72_invalid_check_clause.py
@@ -15,7 +15,7 @@ PostgreSQL's rules, per ``CREATE POLICY``:
   * UPDATE / ALL     -> both USING and WITH CHECK
 """
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from django.db import connection, models
@@ -87,6 +87,28 @@ class TestSchemaEditorClauseGatingForModelPolicy(TestCase):
         sql = self.editor.execute.call_args[0][0]
         assert "USING (" in sql
         assert "WITH CHECK (" not in sql
+
+    def test_compiles_sql_only_once_when_both_clauses_are_needed(self):
+        """Compiling a Q object (filter rewriting + running the SQL
+        compiler) is expensive; UPDATE/ALL policies need both USING and
+        WITH CHECK but must only pay for compilation once."""
+        for operation in (BasePolicy.UPDATE, BasePolicy.ALL):
+            with self.subTest(operation=operation):
+                policy = ModelPolicy(
+                    f"policy_{operation.lower()}",
+                    filters=Q(country="US"),
+                    operation=operation,
+                )
+                with patch.object(
+                    ModelPolicy, "get_compiled_sql", wraps=policy.get_compiled_sql
+                ) as spy:
+                    self.editor.execute.reset_mock()
+                    self.editor.create_policy(self.model, policy)
+
+                assert spy.call_count == 1
+                sql = self.editor.execute.call_args[0][0]
+                assert "USING (" in sql
+                assert "WITH CHECK (" in sql
 
 
 class TestSchemaEditorClauseGatingForExpressionPolicy(TestCase):


### PR DESCRIPTION
ModelPolicy(operation=SELECT) (and DELETE) emitted an invalid WITH CHECK clause alongside USING, which PostgreSQL rejects: "WITH CHECK cannot be applied to SELECT or DELETE". The schema editor called policy.get_compiled_sql(model) unconditionally for both clauses whenever a policy exposed model-aware compilation, ignoring policy.operation.

Centralize clause generation in RLSDatabaseSchemaEditor._build_clauses(), used by both create_policy and alter_policy, gated on operation per Postgres's rules: SELECT/DELETE -> USING only, INSERT -> WITH CHECK only, UPDATE/ALL -> both. BasePolicy.get_using_expression() is likewise now omitted for INSERT-only policies.

Fixes #72

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Please delete options that are not relevant -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring
- [ ] 🔒 Security fix

## Related Issue
<!-- Please link to the issue here -->
Fixes #(issue number)

## Changes Made
<!-- List the main changes made in this PR -->

- 
- 
- 

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [ ] All existing tests pass
- [ ] Added new tests for new functionality
- [ ] Tested with PostgreSQL version: <!-- specify version -->
- [ ] Tested with Django version: <!-- specify version -->
- [ ] Manual testing completed

### Test Configuration
- **Python version**:
- **Django version**:
- **PostgreSQL version**:

## Security Checklist
<!-- Important for RLS-related changes -->

- [ ] No SQL injection vulnerabilities introduced
- [ ] RLS policies cannot be bypassed
- [ ] Context isolation is maintained
- [ ] No sensitive data exposed in logs/errors
- [ ] Proper permission checks in place
- [ ] Database privileges are correctly enforced

## Documentation
<!-- Check all that apply -->

- [ ] Code includes inline documentation
- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [ ] Migration guide provided (for breaking changes)

## Performance Impact
<!-- Describe any performance implications -->

- [ ] Database queries optimized
- [ ] No N+1 query problems
- [ ] RLS policies are efficient
- [ ] Benchmarks run (if applicable)

## Checklist
<!-- Ensure all items are checked before submitting -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->